### PR TITLE
Scaffold `reduce` and change to annotate along.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ From the MDN documentation:
 This means that `forEach` is a poor choice for an operation on an array that may
 terminate early.
 
-### Code along: modeling and using `reduce`
+### Annotate along: modeling and using `reduce`
 
 The
 [reduce](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce)

--- a/lib/reduce.js
+++ b/lib/reduce.js
@@ -1,7 +1,21 @@
 'use strict';
 
-let reduce = function (/* array, callback, init */) {
+let reduce = function (array, callback, init) {
+  let previous;
+  if (typeof init !== 'undefined') {
+    previous = init;
+    array.forEach(function (e, i, a) {
+      previous = callback(previous, e, i, a);
+    });
+  } else {
+    let slice = array.slice(1);
+    previous = array[0];
+    slice.forEach(function (e, i) {
+      previous = callback(previous, e, i + 1, array);
+    });
+  }
 
+  return previous;
 };
 
 module.exports = reduce;


### PR DESCRIPTION
Reduce cognitive load and help demystify functionality.